### PR TITLE
fix: cast to string AttributeField value, strip list items separately

### DIFF
--- a/import_export/fields.py
+++ b/import_export/fields.py
@@ -368,9 +368,10 @@ class AttributeField(Field):
             if value is '' or value is None:
                 return
 
-            values = value.strip().split(';')
+            values = str(value).strip().split(';')
             group = AttributeOptionGroup.objects.get(id=attr_id, is_active=is_active)
             for value in values:
+                value = value.strip()
                 attr_option = AttributeOption.objects.filter(product_class=obj.product_class, group=group, translations__name=value)
                 if attr_option.count() == 0:
                     attr_option = AttributeOption(


### PR DESCRIPTION
**Problem**

Číslo řádku: 1 - 'int' object has no attribute 'strip'
cell might have been loaded as integer or any other type -> import_export/formats/base_formats.py:211
attribute value is type of Char -> django_smartshop/sbcore/catalog/models.py:137
**Solution**

How did you solve the problem?

casting to str(value)

Have you written tests? Have you included screenshots of your changes if applicable?
Did you document your changes? 